### PR TITLE
Adds user customizable hint keys

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,14 @@ Bind the function `mjolnir.th.hints.windowHints` in your `init.lua` to a key lik
 local hints = require "mjolnir.th.hints"
 hotkey.bind({"cmd"},"e",hints.windowHints)
 ```
+
+By default, the hint keys used are: `A O E U I D H T N S P G M W V J K X B Y F`. To customize the hint keys, change the `hints.HINTCHARS` value to the prefered keys before declaring any bindings:
+
+```lua
+local hints = require "mjolnir.th.hints"
+hints.HINTCHARS = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
+```
+
 You can also use `hints.appHints` to switch between windows in an app:
 
 ```lua

--- a/hints.lua
+++ b/hints.lua
@@ -6,7 +6,7 @@ local screen = require "mjolnir.screen"
 local window = require "mjolnir.window"
 local modal_hotkey = require "mjolnir._asm.modal_hotkey"
 
-local hintChars = {"A","O","E","U","I","D","H","T","N","S","P","G",
+hints.HINTCHARS = {"A","O","E","U","I","D","H","T","N","S","P","G",
                    "M","W","V","J","K","X","B","Y","F"}
 local usedChars = 0
 
@@ -54,7 +54,7 @@ function hints.newWinChar(win,extraTxt)
   if usedChars == 0 then
     modalKey:enter()
   end
-  local char = hintChars[usedChars+1]
+  local char = hints.HINTCHARS[usedChars+1]
   hintDict[char] = win
   usedChars = usedChars + 1
 
@@ -88,7 +88,7 @@ function hints._setupModal()
   k = modal_hotkey.new({"cmd", "shift"}, "V")
   k:bind({}, 'escape', function() hints.closeAll(); k:exit() end)
 
-  for i,c in ipairs(hintChars) do
+  for i,c in ipairs(hints.HINTCHARS) do
     k:bind({}, c, hints._createHandler(c))
   end
   return k


### PR DESCRIPTION
This allows the user to customize the hint keys they wish to use, by modifying `hints.HINTCHARS` (closing #6).
