### PR TITLE
Add activeWindowHints

### DIFF
--- a/hints.lua
+++ b/hints.lua
@@ -105,6 +105,16 @@ function hints.windowHints()
   end
 end
 
+-- Create windw hints for all active windows for fast switching
+function hints.activeWindowHints()
+  hints.closeAll()
+  for i,win in ipairs(window.visiblewindows()) do
+    if win:title() ~= "" then
+      hints.newWinChar(win,"")
+    end
+  end
+end
+
 -- Create window hints for a specific app
 function hints.appHints(app)
   if app == nil then return end


### PR DESCRIPTION
Avoid inactive windows (e.g., minimized widows or widgets) to appear in the activeWindows hints.