### PR TITLE
For windows hints, don't rely on empty title

### DIFF
--- a/hints.lua
+++ b/hints.lua
@@ -99,7 +99,7 @@ modalKey = hints._setupModal()
 function hints.windowHints()
   hints.closeAll()
   for i,win in ipairs(window.allwindows()) do
-    if win:title() ~= "" then
+    if win:isstandard() then
       hints.newWinChar(win,"")
     end
   end


### PR DESCRIPTION
Some applications, like the hipchat client, don't have a title and therefore they do not get a hint.

By using mjolnir `isstandard` function, such windows are included as well.
